### PR TITLE
add support for Users

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: "actions/checkout@v2.3.2"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@2.4.1"
+        uses: "shivammathur/setup-php@2.8.0"
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -43,8 +43,8 @@ jobs:
         run: "composer validate --strict"
 
       - name: "Determine composer cache directory"
-        id: "determine-composer-cache-directory"
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+        shell: "bash"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache PHAR files installed with phive"
         uses: "actions/cache@v2.1.0"
@@ -75,7 +75,7 @@ jobs:
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2.1.0"
         with:
-          path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
@@ -118,7 +118,7 @@ jobs:
         uses: "actions/checkout@v2.3.2"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@2.4.1"
+        uses: "shivammathur/setup-php@2.8.0"
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -126,8 +126,8 @@ jobs:
           tools: "composer:v1"
 
       - name: "Determine composer cache directory"
-        id: "determine-composer-cache-directory"
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+        shell: "bash"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache PHAR files installed with phive"
         uses: "actions/cache@v2.1.0"
@@ -158,7 +158,7 @@ jobs:
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2.1.0"
         with:
-          path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
@@ -211,7 +211,7 @@ jobs:
         uses: "actions/checkout@v2.3.2"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@2.4.1"
+        uses: "shivammathur/setup-php@2.8.0"
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -219,13 +219,13 @@ jobs:
           tools: "composer:v1"
 
       - name: "Determine composer cache directory"
-        id: "determine-composer-cache-directory"
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+        shell: "bash"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2.1.0"
         with:
-          path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 
@@ -265,7 +265,7 @@ jobs:
         uses: "actions/checkout@v2.3.2"
 
       - name: "Install PHP with extensions"
-        uses: "shivammathur/setup-php@2.4.1"
+        uses: "shivammathur/setup-php@2.8.0"
         with:
           php-version: "${{ matrix.php-version }}"
           extensions: "${{ env.PHP_EXTENSIONS }}"
@@ -273,13 +273,13 @@ jobs:
           tools: "composer:v1"
 
       - name: "Determine composer cache directory"
-        id: "determine-composer-cache-directory"
-        run: "echo \"::set-output name=directory::$(composer config cache-dir)\""
+        shell: "bash"
+        run: "echo \"COMPOSER_CACHE_DIR=$(composer config cache-dir)\" >> $GITHUB_ENV"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2.1.0"
         with:
-          path: "${{ steps.determine-composer-cache-directory.outputs.directory }}"
+          path: "${{ env.COMPOSER_CACHE_DIR }}"
           key: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-${{ hashFiles('composer.lock') }}"
           restore-keys: "php-${{ matrix.php-version }}-composer-${{ matrix.dependencies }}-"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,28 +49,20 @@ jobs:
       - name: "Cache PHAR files installed with phive"
         uses: "actions/cache@v2.1.0"
         with:
-          path: "~/.phive"
+          path: "${{ runner.temp }}/.phive"
           key: "php-${{ matrix.php-version }}-phive-${{ matrix.dependencies }}-${{ hashFiles('.phive/phars.xml') }}"
           restore-keys: "php-${{ matrix.php-version }}-phive-${{ matrix.dependencies }}-"
 
-      - name: "Install phive from cache"
-        run: |
-          if [ ! -r "${HOME}/.phive/phive.phar" ]; then
-            mkdir -p "${HOME}/bin" "${HOME}/.phive"
-            wget -O "${HOME}/.phive/phive.phar" "https://phar.io/releases/phive.phar"
-            wget -O "${HOME}/.phive/phive.phar.asc" "https://phar.io/releases/phive.phar.asc"
-            gpg --batch --keyserver ha.pool.sks-keyservers.net --keyserver-options timeout=30 --recv-keys 0x9D8A98B29B2D5D79 \
-              || gpg --batch --keyserver ha.pool.sks-keyservers.net --keyserver-options timeout=30 --recv-keys 0x9D8A98B29B2D5D79
-            if ! gpg --batch --verify "${HOME}/.phive/phive.phar.asc" "${HOME}/.phive/phive.phar"; then
-              echo "Invalid phive signature" 1>&2
-              rm -f "${HOME}/.phive/phive.phar"
-              exit 11
-            fi
-            rm "${HOME}/.phive/phive.phar.asc"
-          fi
-          install --verbose --mode=0755 -T -D "${HOME}/.phive/phive.phar" "${HOME}/bin/phive"
-          echo "::add-path::${HOME}/bin"
-          "${HOME}/bin/phive" install --trust-gpg-keys C00543248C87FB13,31C7E470E2138192
+      - name: "Install PHIVE"
+        uses: "szepeviktor/phive@v1"
+        with:
+          home: "${{ runner.temp }}/.phive"
+
+      - name: "Install PHP tools with PHIVE"
+        uses: "szepeviktor/phive-install@v1"
+        with:
+          home: "${{ runner.temp }}/.phive"
+          trustGpgKeys: "C00543248C87FB13,31C7E470E2138192"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2.1.0"
@@ -132,28 +124,20 @@ jobs:
       - name: "Cache PHAR files installed with phive"
         uses: "actions/cache@v2.1.0"
         with:
-          path: "~/.phive"
+          path: "${{ runner.temp }}/.phive"
           key: "php-${{ matrix.php-version }}-phive-${{ matrix.dependencies }}-${{ hashFiles('.phive/phars.xml') }}"
           restore-keys: "php-${{ matrix.php-version }}-phive-${{ matrix.dependencies }}-"
 
-      - name: "Install phive from cache"
-        run: |
-          if [ ! -r "${HOME}/.phive/phive.phar" ]; then
-            mkdir -p "${HOME}/bin" "${HOME}/.phive"
-            wget -O "${HOME}/.phive/phive.phar" "https://phar.io/releases/phive.phar"
-            wget -O "${HOME}/.phive/phive.phar.asc" "https://phar.io/releases/phive.phar.asc"
-            gpg --batch --keyserver ha.pool.sks-keyservers.net --keyserver-options timeout=30 --recv-keys 0x9D8A98B29B2D5D79 \
-              || gpg --batch --keyserver ha.pool.sks-keyservers.net --keyserver-options timeout=30 --recv-keys 0x9D8A98B29B2D5D79
-            if ! gpg --batch --verify "${HOME}/.phive/phive.phar.asc" "${HOME}/.phive/phive.phar"; then
-              echo "Invalid phive signature" 1>&2
-              rm -f "${HOME}/.phive/phive.phar"
-              exit 11
-            fi
-            rm "${HOME}/.phive/phive.phar.asc"
-          fi
-          install --verbose --mode=0755 -T -D "${HOME}/.phive/phive.phar" "${HOME}/bin/phive"
-          echo "::add-path::${HOME}/bin"
-          "${HOME}/bin/phive" install --trust-gpg-keys C00543248C87FB13,31C7E470E2138192
+      - name: "Install PHIVE"
+        uses: "szepeviktor/phive@v1"
+        with:
+          home: "${{ runner.temp }}/.phive"
+
+      - name: "Install PHP tools with PHIVE"
+        uses: "szepeviktor/phive-install@v1"
+        with:
+          home: "${{ runner.temp }}/.phive"
+          trustGpgKeys: "C00543248C87FB13,31C7E470E2138192"
 
       - name: "Cache dependencies installed with composer"
         uses: "actions/cache@v2.1.0"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Manipulating (creating, updating, deleting) posts and attachments will work. Fet
 * `wp_get_attachment_image`
 * and almost anything related to the manipulation of one attachment
 
-Note: Fetching posts using `WP_Query` will not work (yet)! To fetech a post, use `get_post( $id )`.
+Note: Fetching posts using `WP_Query` will not work (yet)! To fetch a post, use `get_post( $id )`.
 
 #### Users and capabilities
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,32 @@ Manipulating (creating, updating, deleting) posts and attachments will work. Fet
 * `wp_get_attachment_image`
 * and almost anything related to the manipulation of one attachment
 
-Note: Fetching for posts using `WP_Query` will not work (yet)! To get a post use `get_post( $id )`.
+Note: Fetching posts using `WP_Query` will not work (yet)! To fetech a post, use `get_post( $id )`.
+
+#### Users and capabilities
+
+You can create, edit and delete users.
+
+Here is a non-exaustive list of functions supported:
+
+* `wp_insert_user`
+* `wp_update_user`
+* `wp_delete_user`
+* `get_userdata`
+* `new WP_User( $id )` to fetch a user
+* `user_can`
+* `current_user_can`
+* `set_current_user`
+* `get_current_user_id`
+* `wp_get_current_user`
+* `get_user_meta`
+* `update_user_meta`
+* `add_user_meta`
+* `delete_user_meta`
+
+Posts can be assigned to users and proper capabilities will be correctly checked. When deleting a user, reassigning posts to other user will also work.
+
+Note: Fetching users using `WP_Users_Query` will not work! To fetch a user, use `get_userdata()`, `get_user_by` or `WP_User` class.
 
 ### Populating default options
 

--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -25,6 +25,7 @@ abstract class BaseTestCase extends TestCase {
 		Options::init()->clear_options();
 		Posts::init()->clear_all_posts();
 		PostMeta::init()->clear_all_meta();
+		Users::init()->clear_all_users();
 		$this->clear_uploads();
 	}
 

--- a/src/ClearCacheGroup.php
+++ b/src/ClearCacheGroup.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WorDBless;
+
+trait ClearCacheGroup {
+
+	/**
+	 * Clears the cache for the current group
+	 *
+	 * @return void
+	 */
+	public function clear_cache_group() {
+		global $wp_object_cache;
+
+		if ( ! $this->cache_group ) {
+			return;
+		}
+
+		if ( ! isset( $wp_object_cache->cache[ $this->cache_group ] ) || ! is_array( $wp_object_cache->cache[ $this->cache_group ] ) ) {
+			return;
+		}
+
+		foreach ( array_keys( $wp_object_cache->cache[ $this->cache_group ] ) as $key ) {
+			wp_cache_delete( $key, $this->cache_group );
+		}
+	}
+
+}

--- a/src/Load.php
+++ b/src/Load.php
@@ -29,6 +29,8 @@ class Load {
 		Options::init();
 		Posts::init();
 		PostMeta::init();
+		Users::init();
+		UserMeta::init();
 		WpDie::init();
 	}
 

--- a/src/Load.php
+++ b/src/Load.php
@@ -23,8 +23,8 @@ class Load {
 		define( 'WP_REPAIRING', true ); // Will not try to install WordPress
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
 
-		$_SERVER['SERVER_NAME'] = 'anything.com';
-		$_SERVER['HTTP_HOST']   = 'anything.com';
+		$_SERVER['SERVER_NAME'] = 'anything.example';
+		$_SERVER['HTTP_HOST']   = 'anything.example';
 
 		global $table_prefix;
 		$table_prefix = 'wp_';

--- a/src/Load.php
+++ b/src/Load.php
@@ -16,9 +16,6 @@ class Load {
 		if ( ! defined( 'ABSPATH' ) ) {
 			define( 'ABSPATH', __DIR__ . '/../../../../wordpress/' );
 		}
-		if ( ! defined( 'WPINC' ) ) {
-			define( 'WPINC', 'wp-includes' );
-		}
 
 		define( 'WP_REPAIRING', true ); // Will not try to install WordPress
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );

--- a/src/Load.php
+++ b/src/Load.php
@@ -16,9 +16,18 @@ class Load {
 		if ( ! defined( 'ABSPATH' ) ) {
 			define( 'ABSPATH', __DIR__ . '/../../../../wordpress/' );
 		}
+		if ( ! defined( 'WPINC' ) ) {
+			define( 'WPINC', 'wp-includes' );
+		}
 
 		define( 'WP_REPAIRING', true ); // Will not try to install WordPress
 		define( 'WP_CONTENT_DIR', ABSPATH . 'wp-content' );
+
+		$_SERVER['SERVER_NAME'] = 'anything.com';
+		$_SERVER['HTTP_HOST']   = 'anything.com';
+
+		global $table_prefix;
+		$table_prefix = 'wp_';
 
 		require ABSPATH . '/wp-settings.php';
 		require_once ABSPATH . 'wp-admin/includes/admin.php';

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -1,0 +1,272 @@
+<?php
+
+namespace WorDBless;
+
+class Metadata {
+
+	public $meta = array();
+
+	public $meta_type;
+
+	public function __construct( $meta_type ) {
+
+		$this->meta_type = $meta_type;
+
+		add_filter( "add_{$this->meta_type}_metadata", array( $this, 'add' ), 10, 5 );
+
+		add_filter( "get_{$this->meta_type}_metadata", array( $this, 'get' ), 10, 4 );
+		add_filter( "get_{$this->meta_type}_metadata_by_mid", array( $this, 'get_by_mid' ), 10, 2 );
+
+		add_filter( "delete_{$this->meta_type}_metadata", array( $this, 'delete' ), 10, 5 );
+		add_filter( "delete_{$this->meta_type}_metadata_by_mid", array( $this, 'delete_by_mid' ), 10, 2 );
+
+		add_filter( "update_{$this->meta_type}_metadata", array( $this, 'update' ), 10, 5 );
+		add_filter( "update_{$this->meta_type}_metadata_by_mid", array( $this, 'update_by_mid' ), 10, 4 );
+
+	}
+
+	public function key_exists_for_object( $meta_key, $object_id ) {
+		if ( ! isset( $this->meta[ $object_id ] ) ) {
+			return false;
+		}
+
+		foreach ( $this->meta[ $object_id ] as $meta ) {
+			if ( isset( $meta['meta_key'] ) && $meta_key === $meta['meta_key'] ) {
+				return true;
+			}
+		}
+
+		return false;
+
+	}
+
+	public function add( $check, $object_id, $meta_key, $meta_value, $unique ) {
+
+		if ( $unique && $this->key_exists_for_object( $meta_key, $object_id ) ) {
+			return false;
+		}
+
+		$_meta_value = $meta_value;
+		$meta_value  = maybe_serialize( $meta_value );
+
+		if ( ! isset( $this->meta[ $object_id ] ) ) {
+			$this->meta[ $object_id ] = array();
+		}
+
+		do_action( "add_{$this->meta_type}_meta", $object_id, $meta_key, $_meta_value );
+
+		$mid = InsertId::bump_and_get();
+
+		$this->meta[ $object_id ][] = array(
+			'mid'        => $mid,
+			'meta_key'   => $meta_key,
+			'meta_value' => $meta_value,
+		);
+
+		do_action( "added_{$this->meta_type}_meta", $mid, $object_id, $meta_key, $_meta_value );
+
+		return $mid;
+
+	}
+
+	public function get( $check, $object_id, $meta_key, $single ) {
+		$check = array();
+		if ( isset( $this->meta[ $object_id ] ) ) {
+			foreach ( $this->meta[ $object_id ] as $meta ) {
+				if ( isset( $meta['meta_key'] ) && $meta_key === $meta['meta_key'] ) {
+					$check[] = maybe_unserialize( $meta['meta_value'] );
+					if ( $single ) {
+						break;
+					}
+				}
+			}
+		}
+		return $check;
+	}
+
+	protected function find_by_mid( $mid ) {
+
+		foreach ( $this->meta as $object_id => $object_meta ) {
+			foreach ( $object_meta as $index => $meta ) {
+				if ( isset( $meta['mid'] ) && $mid === $meta['mid'] ) {
+					return array(
+						'object_id' => $object_id,
+						'index'     => $index,
+						'key'       => $meta['meta_key'],
+						'value'     => $meta['meta_value'],
+					);
+				}
+			}
+		}
+
+		return false;
+
+	}
+
+	public function get_by_mid( $check, $mid ) {
+		$check = false;
+		$meta  = $this->find_by_mid( $mid );
+		if ( $meta ) {
+			$check = maybe_unserialize( $meta['value'] );
+		}
+		return $check;
+	}
+
+	public function delete( $check, $object_id, $meta_key, $meta_value, $delete_all ) {
+
+		$object_ids = $delete_all ? array_keys( $this->meta ) : array( $object_id );
+		$check      = false;
+
+		foreach ( $object_ids as $id ) {
+			if ( $this->delete_for_object( $id, $meta_key, $meta_value ) ) {
+				$check = true;
+			}
+		}
+
+		return $check;
+
+	}
+
+	public function delete_for_object( $object_id, $meta_key, $meta_value ) {
+		if ( ! isset( $this->meta[ $object_id ] ) ) {
+			return false;
+		}
+
+		$meta_value          = maybe_serialize( $meta_value );
+		$consider_meta_value = '' !== $meta_value && null !== $meta_value && false !== $meta_value;
+		$found               = false;
+
+		foreach ( $this->meta[ $object_id ] as $index => $meta ) {
+			if (
+				isset( $meta['meta_key'] ) &&
+				$meta_key === $meta['meta_key'] &&
+				(
+					! $consider_meta_value ||
+					$meta_value === $meta['meta_value']
+				)
+			) {
+				unset( $this->meta[ $object_id ][ $index ] );
+				$found = true;
+			}
+		}
+
+		$this->meta[ $object_id ] = array_values( $this->meta[ $object_id ] );
+
+		return $found;
+
+	}
+
+	public function delete_by_mid( $check, $mid ) {
+		$check = false;
+		$meta  = $this->find_by_mid( $mid );
+		if ( $meta ) {
+			unset( $this->meta[ $meta['object_id'] ][ $meta['index'] ] );
+			$this->meta[ $meta['object_id'] ] = array_values( $this->meta[ $meta['object_id'] ] );
+			$check                            = true;
+		}
+		return $check;
+	}
+
+	public function update( $check, $object_id, $meta_key, $meta_value, $prev_value ) {
+
+		if ( ! $this->key_exists_for_object( $meta_key, $object_id ) ) {
+			// todo: in the original method, raw values are passade to add_metadata. The values below have been through wp_unslash.
+			return add_metadata( $this->meta_type, $object_id, $meta_key, $meta_value );
+		}
+
+		// Compare existing value to new value if no prev value given and the key exists only once.
+		if ( empty( $prev_value ) ) {
+			$old_value = get_metadata( $this->meta_type, $object_id, $meta_key );
+			if ( 1 === count( $old_value ) ) {
+				if ( $old_value[0] === $meta_value ) {
+					return false;
+				}
+			}
+		}
+
+		$_meta_value = $meta_value;
+		$meta_value  = maybe_serialize( $meta_value );
+
+		$consider_meta_value = '' !== $prev_value && null !== $prev_value && false !== $prev_value;
+
+		$check = false;
+
+		foreach ( $this->meta[ $object_id ] as $index => $meta ) {
+			if (
+				isset( $meta['meta_key'] ) &&
+				$meta_key === $meta['meta_key'] &&
+				(
+					! $consider_meta_value ||
+					$prev_value === $meta['meta_value']
+				)
+			) {
+
+				do_action( "update_{$this->meta_type}_meta", $meta['mid'], $object_id, $meta_key, $_meta_value );
+				if ( 'post' === $this->meta_type ) {
+					do_action( 'update_postmeta', $meta['mid'], $object_id, $meta_key, $meta_value );
+				}
+
+				$this->meta[ $object_id ][ $index ]['meta_value'] = $meta_value;
+
+				do_action( "updated_{$this->meta_type}_meta", $meta['mid'], $object_id, $meta_key, $_meta_value );
+				if ( 'post' === $this->meta_type ) {
+					do_action( 'updated_postmeta', $meta['mid'], $object_id, $meta_key, $meta_value );
+				}
+
+				$check = true;
+			}
+		}
+
+		return $check;
+
+	}
+
+	public function update_by_mid( $check, $mid, $meta_value, $meta_key ) {
+		$check = false;
+		$meta  = $this->find_by_mid( $mid );
+		if ( $meta ) {
+
+			$meta_subtype = get_object_subtype( $this->meta_type, $meta['object_id'] );
+			$_meta_value  = $meta_value;
+			$meta_value   = sanitize_meta( $meta_key, $meta_value, $this->meta_type, $meta_subtype );
+			$meta_value   = maybe_serialize( $meta_value );
+			$new_key      = false === $meta_key ? $meta['key'] : $meta_key;
+
+			/** This action is documented in wp-includes/meta.php */
+			do_action( "update_{$this->meta_type}_meta", $mid, $meta['object_id'], $meta_key, $_meta_value );
+
+			if ( 'post' === $this->meta_type ) {
+				/** This action is documented in wp-includes/meta.php */
+				do_action( 'update_postmeta', $mid, $meta['object_id'], $meta_key, $meta_value );
+			}
+
+			$this->meta[ $meta['object_id'] ][ $meta['index'] ] = array(
+				'mid'        => $mid,
+				'meta_key'   => $new_key,
+				'meta_value' => $meta_value,
+			);
+
+			/** This action is documented in wp-includes/meta.php */
+			do_action( "updated_{$this->meta_type}_meta", $mid, $meta['object_id'], $meta_key, $_meta_value );
+
+			if ( 'post' === $this->meta_type ) {
+				/** This action is documented in wp-includes/meta.php */
+				do_action( 'updated_postmeta', $mid, $meta['object_id'], $meta_key, $meta_value );
+			}
+
+			$check = true;
+		}
+		return $check;
+	}
+
+	public function clear_all_meta() {
+		$this->meta = array();
+	}
+
+	public function clear_all_meta_for_object( $object_id ) {
+		if ( isset( $this->meta[ $object_id ] ) ) {
+			unset( $this->meta[ $object_id ] );
+		}
+	}
+
+}

--- a/src/Metadata.php
+++ b/src/Metadata.php
@@ -81,6 +81,9 @@ class Metadata {
 				}
 			}
 		}
+		if ( empty( $check ) && $single ) {
+			$check = array( '' ); // Ensure an empty string is returned when meta is not found.
+		}
 		return $check;
 	}
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -47,9 +47,15 @@ class Options {
 	 */
 	public function filter_query( $query_results, $query ) {
 		global $wpdb;
-		$pattern = '/^SELECT autoload FROM ' . preg_quote( $wpdb->options ) . ' WHERE option_name = [^ ]+$/';
+		$pattern = '/^SELECT autoload FROM ' . preg_quote( $wpdb->options ) . ' WHERE option_name = \'([^ ]+)\'$/';
 		if ( 1 === preg_match( $pattern, $query, $matches ) ) {
-			return array( 'yes' );
+			if ( isset( $this->get_all_options()[ $matches[1] ] ) ) {
+				return array(
+					(object) array(
+						'autoload' => 'no',
+					)
+				);
+			}
 		}
 		return $query_results;
 	}
@@ -72,7 +78,7 @@ class Options {
 	 * @param array $options
 	 * @return array
 	 */
-	public function get_all_options( $options ) {
+	public function get_all_options( $options = array() ) {
 
 		$defaults = $this->get_default_options();
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -26,7 +26,6 @@ class Options {
 
 		add_filter( 'wordbless_wpdb_query_results', array( $this, 'filter_query' ), 10, 2 );
 		$this->clear_cache_group();
-
 	}
 
 	/**
@@ -53,7 +52,7 @@ class Options {
 				return array(
 					(object) array(
 						'autoload' => 'no',
-					)
+					),
 				);
 			}
 		}
@@ -79,7 +78,6 @@ class Options {
 	 * @return array
 	 */
 	public function get_all_options( $options = array() ) {
-
 		$defaults = $this->get_default_options();
 
 		if ( ! is_array( $options ) ) {
@@ -115,7 +113,6 @@ class Options {
 	public function delete_option( $option ) {
 		unset( $this->options[ $option ] );
 		$this->clear_cache_group();
-
 	}
 
 	/**
@@ -133,7 +130,6 @@ class Options {
 		foreach ( array_keys( $wp_object_cache->cache['options'] ) as $key ) {
 			wp_cache_delete( $key, 'options' );
 		}
-
 	}
 
 }

--- a/src/Options.php
+++ b/src/Options.php
@@ -9,7 +9,9 @@ use function dbless_default_options;
  */
 class Options {
 
-	use Singleton;
+	use Singleton, ClearCacheGroup;
+
+	public $cache_group = 'options';
 
 	/**
 	 * Holds the stored options
@@ -113,23 +115,6 @@ class Options {
 	public function delete_option( $option ) {
 		unset( $this->options[ $option ] );
 		$this->clear_cache_group();
-	}
-
-	/**
-	 * Clears the cache for the 'options' group
-	 *
-	 * @return void
-	 */
-	public function clear_cache_group() {
-		global $wp_object_cache;
-
-		if ( ! isset( $wp_object_cache->cache['options'] ) || ! is_array( $wp_object_cache->cache['options'] ) ) {
-			return;
-		}
-
-		foreach ( array_keys( $wp_object_cache->cache['options'] ) as $key ) {
-			wp_cache_delete( $key, 'options' );
-		}
 	}
 
 }

--- a/src/PostMeta.php
+++ b/src/PostMeta.php
@@ -2,7 +2,7 @@
 
 namespace WorDBless;
 
-class PostMeta extends Metadata {
+class PostMeta {
 
 	private static $instance = null;
 

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -4,9 +4,10 @@ namespace WorDBless;
 
 class Posts {
 
-	use Singleton;
+	use Singleton, ClearCacheGroup;
 
-	public $posts = array();
+	public $posts       = array();
+	public $cache_group = 'posts';
 
 	private function __construct() {
 		add_filter( 'wp_insert_post_data', array( $this, 'insert_post' ), 10, 3 );
@@ -64,6 +65,7 @@ class Posts {
 				return $post->post_author !== $author_id;
 			}
 		);
+		$this->clear_cache_group();
 	}
 
 	public function transfer_posts_authorship( $author_id_from, $author_id_to ) {
@@ -76,6 +78,7 @@ class Posts {
 			},
 			$this->posts
 		);
+		$this->clear_cache_group();
 	}
 
 }

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -60,7 +60,7 @@ class Posts {
 	public function clear_all_posts_from_author( $author_id ) {
 		$this->posts = array_filter(
 			$this->posts,
-			function( $post ) use( $author_id ) {
+			function( $post ) use ( $author_id ) {
 				return $post->post_author !== $author_id;
 			}
 		);
@@ -68,7 +68,7 @@ class Posts {
 
 	public function transfer_posts_authorship( $author_id_from, $author_id_to ) {
 		$this->posts = array_map(
-			function( $post ) use( $author_id_from, $author_id_to ) {
+			function( $post ) use ( $author_id_from, $author_id_to ) {
 				if ( $post->post_author === $author_id_from ) {
 					$post->post_author = $author_id_to;
 				}

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -57,5 +57,25 @@ class Posts {
 		$this->posts = array();
 	}
 
+	public function clear_all_posts_from_author( $author_id ) {
+		$this->posts = array_filter(
+			$this->posts,
+			function( $post ) use( $author_id ) {
+				return $post->post_author !== $author_id;
+			}
+		);
+	}
+
+	public function transfer_posts_authorship( $author_id_from, $author_id_to ) {
+		$this->posts = array_map(
+			function( $post ) use( $author_id_from, $author_id_to ) {
+				if ( $post->post_author === $author_id_from ) {
+					$post->post_author = $author_id_to;
+				}
+				return $post;
+			},
+			$this->posts
+		);
+	}
 
 }

--- a/src/UserMeta.php
+++ b/src/UserMeta.php
@@ -2,13 +2,13 @@
 
 namespace WorDBless;
 
-class PostMeta extends Metadata {
+class UserMeta extends Metadata {
 
 	private static $instance = null;
 
 	public static function init() {
 		if ( null === self::$instance ) {
-			self::$instance = new Metadata( 'post' );
+			self::$instance = new Metadata( 'user' );
 		}
 		return self::$instance;
 	}

--- a/src/UserMeta.php
+++ b/src/UserMeta.php
@@ -2,7 +2,7 @@
 
 namespace WorDBless;
 
-class UserMeta extends Metadata {
+class UserMeta {
 
 	private static $instance = null;
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -4,12 +4,12 @@ namespace WorDBless;
 
 class Users {
 
-	use Singleton;
+	use Singleton, ClearCacheGroup;
 
-	public $users = array();
+	public $users       = array();
+	public $cache_group = 'users';
 
 	private function __construct() {
-
 		require_once ABSPATH . 'wp-admin/includes/schema.php';
 		populate_roles();
 
@@ -28,7 +28,6 @@ class Users {
 	 *
 	 */
 	public function insert( $result, $table, $data, $format ) {
-		wp_cache_flush();
 		global $wpdb;
 
 		if ( $wpdb->users !== $table ) {
@@ -51,7 +50,6 @@ class Users {
 	 *
 	 */
 	public function update( $result, $table, $data, $where, $format, $where_format ) {
-		wp_cache_flush();
 		global $wpdb;
 
 		if ( $wpdb->users !== $table ) {
@@ -94,7 +92,6 @@ class Users {
 	 * @return array
 	 */
 	public function filter_query( $query_results, $query ) {
-		wp_cache_flush();
 		global $wpdb;
 		$pattern = '/^SELECT \* FROM ' . preg_quote( $wpdb->users ) . ' WHERE (ID|user_nicename|user_email|user_login) = \'([^ ]+)\' LIMIT 1$/';
 		if ( 1 === preg_match( $pattern, $query, $matches ) ) {
@@ -127,7 +124,7 @@ class Users {
 	}
 
 	public function clear_all_users() {
-		wp_cache_flush();
+		$this->clear_cache_group();
 		$this->users = array();
 	}
 

--- a/src/Users.php
+++ b/src/Users.php
@@ -108,7 +108,7 @@ class Users {
 	}
 
 	public function get_user_by( $field, $value ) {
-		$user = null;
+		$user = false;
 		if ( 'ID' === $field && isset( $this->users[ $value ] ) ) {
 			$user = (object) $this->users[ $value ];
 		} elseif ( 'ID' !== $field ) {
@@ -119,7 +119,9 @@ class Users {
 				}
 			);
 
-			$user = (object) current( $filtered );
+			if ( ! empty( $filtered ) ) {
+				$user = (object) current( $filtered );
+			}
 		}
 		return $user;
 	}

--- a/src/Users.php
+++ b/src/Users.php
@@ -18,7 +18,7 @@ class Users {
 
 		add_filter( 'wordbless_wpdb_query_results', array( $this, 'filter_query' ), 10, 2 );
 
-		add_action ( 'delete_user', array( $this, 'delete' ), 10, 2 );
+		add_action( 'delete_user', array( $this, 'delete' ), 10, 2 );
 	}
 
 	/**
@@ -60,11 +60,11 @@ class Users {
 
 		if ( is_array( $where ) && 1 === count( $where ) && isset( $where['ID'] ) ) {
 			if ( isset( $this->users[ $where['ID'] ] ) ) {
+				$result                      = 1;
 				$this->users[ $where['ID'] ] = array_merge(
 					$this->users[ $where['ID'] ],
 					$data
 				);
-				$result = 1;
 			}
 		}
 
@@ -114,10 +114,11 @@ class Users {
 		} elseif ( 'ID' !== $field ) {
 			$filtered = array_filter(
 				$this->users,
-				function( $user ) use( $field, $value ) {
+				function( $user ) use ( $field, $value ) {
 					return isset( $user[ $field ] ) && $user[ $field ] === $value;
 				}
 			);
+
 			$user = (object) current( $filtered );
 		}
 		return $user;

--- a/src/Users.php
+++ b/src/Users.php
@@ -1,0 +1,131 @@
+<?php
+
+namespace WorDBless;
+
+class Users {
+
+	use Singleton;
+
+	public $users = array();
+
+	private function __construct() {
+
+		require_once ABSPATH . 'wp-admin/includes/schema.php';
+		populate_roles();
+
+		add_filter( 'wordbless_wpdb_insert', array( $this, 'insert' ), 10, 4 );
+		add_filter( 'wordbless_wpdb_update', array( $this, 'update' ), 10, 6 );
+
+		add_filter( 'wordbless_wpdb_query_results', array( $this, 'filter_query' ), 10, 2 );
+
+		add_action ( 'delete_user', array( $this, 'delete' ), 10, 2 );
+	}
+
+	/**
+	 * Filters the results from $wpdb->insert.
+	 *
+	 * This filter will handle the call for insert() done from wp_insert_post
+	 *
+	 */
+	public function insert( $result, $table, $data, $format ) {
+		wp_cache_flush();
+		global $wpdb;
+
+		if ( $wpdb->users !== $table ) {
+			return $result;
+		}
+
+		$new_id          = InsertId::bump_and_get();
+		$wpdb->insert_id = $new_id;
+		$data['ID']      = $new_id;
+
+		$this->users[ $new_id ] = $data;
+
+		return true;
+	}
+
+	/**
+	 * Filters the results from $wpdb->update.
+	 *
+	 * This filter will handle the call for insert() done from wp_insert_post
+	 *
+	 */
+	public function update( $result, $table, $data, $where, $format, $where_format ) {
+		wp_cache_flush();
+		global $wpdb;
+
+		if ( $wpdb->users !== $table ) {
+			return $result;
+		}
+
+		if ( is_array( $where ) && 1 === count( $where ) && isset( $where['ID'] ) ) {
+			if ( isset( $this->users[ $where['ID'] ] ) ) {
+				$this->users[ $where['ID'] ] = array_merge(
+					$this->users[ $where['ID'] ],
+					$data
+				);
+				$result = 1;
+			}
+		}
+
+		return $result;
+
+	}
+
+	public function delete( $id, $reassign ) {
+
+		if ( $reassign ) {
+			Posts::init()->transfer_posts_authorship( $id, $reassign );
+		} else {
+			Posts::init()->clear_all_posts_from_author( $id );
+		}
+
+		UserMeta::init()->clear_all_meta_for_object( $id );
+
+		unset( $this->users[ $id ] );
+
+	}
+
+	/**
+	 * Filters the Query used in WP_User::get_data_by
+	 *
+	 * @param array  $query_results
+	 * @param string $query
+	 * @return array
+	 */
+	public function filter_query( $query_results, $query ) {
+		wp_cache_flush();
+		global $wpdb;
+		$pattern = '/^SELECT \* FROM ' . preg_quote( $wpdb->users ) . ' WHERE (ID|user_nicename|user_email|user_login) = \'([^ ]+)\' LIMIT 1$/';
+		if ( 1 === preg_match( $pattern, $query, $matches ) ) {
+			$field = $matches[1];
+			$value = $matches[2];
+
+			$query_results = array( $this->get_user_by( $field, $value ) );
+		}
+
+		return $query_results;
+	}
+
+	public function get_user_by( $field, $value ) {
+		$user = null;
+		if ( 'ID' === $field && isset( $this->users[ $value ] ) ) {
+			$user = (object) $this->users[ $value ];
+		} elseif ( 'ID' !== $field ) {
+			$filtered = array_filter(
+				$this->users,
+				function( $user ) use( $field, $value ) {
+					return isset( $user[ $field ] ) && $user[ $field ] === $value;
+				}
+			);
+			$user = (object) current( $filtered );
+		}
+		return $user;
+	}
+
+	public function clear_all_users() {
+		wp_cache_flush();
+		$this->users = array();
+	}
+
+}

--- a/src/dbless-wpdb.php
+++ b/src/dbless-wpdb.php
@@ -42,6 +42,64 @@ class Db_Less_Wpdb extends wpdb {
 		return true;
 	}
 
+	public function update( $table, $data, $where, $format = null, $where_format = null ) {
+		$result = parent::update( $table, $data, $where, $format, $where_format );
+
+		/**
+		 * Filters the return of $wpdb->update
+		 *
+		 * @param int|false    $result The number of rows affected, or false on error.
+		 * @param string       $table The database table.
+		 * @param array        $data Data to update.
+		 * @param array        $where A named array of WHERE clauses.
+		 * @param array|string $format (Optional) An array of formats to be mapped to each of the values in $data. A named array of WHERE clauses.
+		 * @param array|string $where_format (Optional) An array of formats to be mapped to each of the values in $where.
+		 */
+		return apply_filters( 'wordbless_wpdb_update', $result, $table, $data, $where, $format, $where_format );
+	}
+
+	public function insert( $table, $data, $format = null ) {
+		$result = parent::insert( $table, $data, $format );
+
+		/**
+		 * Filters the return of $wpdb->insert
+		 *
+		 * @param int|false    $result The number of rows inserted, or false on error.
+		 * @param string       $table The database table.
+		 * @param array        $data Data to insert.
+		 * @param array|string $format (Optional) An array of formats to be mapped to each of the values in $data. A named array of WHERE clauses.
+		 */
+		return apply_filters( 'wordbless_wpdb_insert', $result, $table, $data, $format );
+	}
+
+	public function delete( $table, $where, $where_format = null ) {
+		$result = parent::delete( $table, $where, $where_format );
+
+		/**
+		 * Filters the return of $wpdb->delete
+		 *
+		 * @param int|false    $result The number of rows affected, or false on error.
+		 * @param string       $table The database table.
+		 * @param array        $where A named array of WHERE clauses.
+		 * @param array|string $where_format (Optional) An array of formats to be mapped to each of the values in $where.
+		 */
+		return apply_filters( 'wordbless_wpdb_delete', $result, $table, $where, $where_format );
+	}
+
+	public function replace( $table, $data, $format = null ) {
+		$result = parent::replace( $table, $data, $format );
+
+		/**
+		 * Filters the return of $wpdb->replace
+		 *
+		 * @param int|false    $result The number of rows affected, or false on error.
+		 * @param string       $table The database table.
+		 * @param array        $table The data to be inserted.
+		 * @param array|string $format (Optional) An array of formats to be mapped to each of the value in $data.
+		 */
+		return apply_filters( 'wordbless_wpdb_replace', $result, $table, $data, $format );
+	}
+
 	public function query( $query ) {
 
 		/**

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,5 +12,6 @@ require_once __DIR__ . '/../vendor/autoload.php';
 
 define( 'ABSPATH', __DIR__ . '/../wordpress/' );
 define( 'TESTSPATH', __DIR__ );
+define( 'WP_DEBUG', true );
 
 \WorDBless\Load::load();

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -32,6 +32,10 @@ class Test_Options extends BaseTestCase {
 		$this->assertEquals( null, get_option( 'testdelete' ) );
 	}
 
+	public function test_delete_non_existent() {
+		$this->assertFalse( delete_option( 'non_existent' ) );
+	}
+
 	/**
 	 * Assert that no error is triggered if you try to delete an option before any option is set.
 	 * See #16

--- a/tests/test-posts.php
+++ b/tests/test-posts.php
@@ -276,4 +276,9 @@ class Test_Posts extends BaseTestCase {
 		$this->assertEmpty( get_post_meta( $id1, 'test', true ) );
 	}
 
+	public function test_get_non_existent_meta() {
+		$this->assertSame( '', get_post_meta( 123123, 'asdasd', true ) );
+		$this->assertSame( array(), get_post_meta( 123123, 'asdasd' ) );
+	}
+
 }

--- a/tests/test-users.php
+++ b/tests/test-users.php
@@ -10,6 +10,7 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
+				'user_pass'  => '123',
 			)
 		);
 
@@ -22,7 +23,8 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
-				'role' => 'subscriber',
+				'user_pass'  => '123',
+				'role'       => 'subscriber',
 			)
 		);
 
@@ -46,6 +48,7 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
+				'user_pass'  => '123',
 			)
 		);
 
@@ -60,6 +63,7 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
+				'user_pass'  => '123',
 			)
 		);
 
@@ -91,6 +95,7 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
+				'user_pass'  => '123',
 			)
 		);
 
@@ -122,7 +127,8 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
-				'role' => 'author',
+				'user_pass'  => '123',
+				'role'       => 'author',
 			)
 		);
 
@@ -142,7 +148,8 @@ class Test_Users extends BaseTestCase {
 		$id = wp_insert_user(
 			array(
 				'user_login' => 'zumbi',
-				'role' => 'author',
+				'user_pass'  => '123',
+				'role'       => 'author',
 			)
 		);
 

--- a/tests/test-users.php
+++ b/tests/test-users.php
@@ -83,7 +83,7 @@ class Test_Users extends BaseTestCase {
 
 		$this->assertFalse( get_userdata( $id ), 'User was not deleted' );
 		$this->assertNull( get_post( $post ), 'Posts from deleted user were not deleted' );
-		$this->assertNull( get_user_meta( $id, 'nickname', true ), 'User metadata was not deleted' );
+		$this->assertEmpty( get_user_meta( $id, 'nickname', true ), 'User metadata was not deleted' );
 
 	}
 

--- a/tests/test-users.php
+++ b/tests/test-users.php
@@ -83,7 +83,7 @@ class Test_Users extends BaseTestCase {
 
 		$this->assertFalse( get_userdata( $id ), 'User was not deleted' );
 		$this->assertNull( get_post( $post ), 'Posts from deleted user were not deleted' );
-		$this->assertEmpty( get_user_meta( $id, 'nickname', true ), 'User metadata was not deleted' );
+		$this->assertSame( '', get_user_meta( $id, 'nickname', true ), 'User metadata was not deleted' );
 
 	}
 

--- a/tests/test-users.php
+++ b/tests/test-users.php
@@ -169,5 +169,9 @@ class Test_Users extends BaseTestCase {
 
 	}
 
+	public function test_get_user_by_dont_find() {
+		$this->assertFalse( get_user_by( 'login', 'asdasd' ) );
+	}
+
 
 }

--- a/tests/test-users.php
+++ b/tests/test-users.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace WorDBless;
+
+use WP_User;
+
+class Test_Users extends BaseTestCase {
+
+	public function test_add() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+			)
+		);
+
+		$this->assertArrayHasKey($id, Users::init()->users );
+		$this->assertSame( 'zumbi', Users::init()->users[ $id ]['user_login'] );
+
+	}
+
+	public function test_init_wp_user() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+				'role' => 'subscriber',
+			)
+		);
+
+		// by id.
+		$user = new WP_User( $id );
+
+		$this->assertInstanceOf( 'WP_User', $user );
+		$this->assertSame( $id, $user->ID );
+		$this->assertSame( 'zumbi', $user->user_login );
+
+		// by login.
+		$user = new WP_User( 'zumbi' );
+
+		$this->assertInstanceOf( 'WP_User', $user );
+		$this->assertSame( $id, $user->ID );
+		$this->assertSame( 'zumbi', $user->user_login );
+
+	}
+
+	public function test_update() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+			)
+		);
+
+		wp_update_user( array( 'ID' => $id, 'user_email' => 'zumbi@palmares.qlb' ) );
+
+		$this->assertArrayHasKey($id, Users::init()->users );
+		$this->assertSame( 'zumbi', Users::init()->users[ $id ]['user_login'] );
+		$this->assertSame( 'zumbi@palmares.qlb', Users::init()->users[ $id ]['user_email'] );
+	}
+
+	public function test_delete() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+			)
+		);
+
+		$post = wp_insert_post(
+			array(
+				'post_title' => 'Test post',
+				'post_content' => 'Test content',
+				'post_status' => 'draft',
+				'post_author' => $id
+			)
+		);
+
+		$user = new WP_User( $id );
+		$saved_post = get_post( $post );
+
+		$this->assertInstanceOf( 'WP_User', $user );
+		$this->assertInstanceOf( 'WP_Post', $saved_post );
+		$this->assertSame( 'zumbi', get_user_meta( $id, 'nickname', true ) );
+
+		wp_delete_user( $id );
+
+		$this->assertFalse( get_userdata( $id ), 'User was not deleted' );
+		$this->assertNull( get_post( $post ), 'Posts from deleted user were not deleted' );
+		$this->assertNull( get_user_meta( $id, 'nickname', true ), 'User metadata was not deleted' );
+
+	}
+
+	public function test_delete_reassign() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+			)
+		);
+
+		$post = wp_insert_post(
+			array(
+				'post_title' => 'Test post',
+				'post_content' => 'Test content',
+				'post_status' => 'draft',
+				'post_author' => $id
+			)
+		);
+
+		$user = new WP_User( $id );
+		$saved_post = get_post( $post );
+
+		$this->assertInstanceOf( 'WP_User', $user );
+		$this->assertInstanceOf( 'WP_Post', $saved_post );
+
+		wp_delete_user( $id, 2222 );
+
+		$this->assertFalse( get_userdata( $id ) );
+
+		$saved_post = get_post( $post );
+		$this->assertSame( 2222, $saved_post->post_author );
+
+	}
+
+	public function test_capabilities() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+				'role' => 'author',
+			)
+		);
+
+		$this->assertTrue( user_can( $id, 'read' ) );
+		$this->assertTrue( user_can( $id, 'edit_posts' ) );
+		$this->assertFalse( user_can( $id, 'manage_options' ) );
+		$this->assertFalse( user_can( $id, 'edit_others_posts' ) );
+		$this->assertFalse( user_can( $id, 'custom_cap' ) );
+
+		$user = get_userdata( $id );
+		$user->add_cap( 'custom_cap' );
+
+		$this->assertTrue( user_can( $id, 'custom_cap' ) );
+	}
+
+	public function test_meta_capabilities() {
+		$id = wp_insert_user(
+			array(
+				'user_login' => 'zumbi',
+				'role' => 'author',
+			)
+		);
+
+		$post = wp_insert_post(
+			array(
+				'post_title' => 'Test post',
+				'post_content' => 'Test content',
+				'post_status' => 'draft',
+				'post_author' => $id
+			)
+		);
+
+		$others = wp_insert_post(
+			array(
+				'post_title' => 'Test post 2',
+				'post_content' => 'Test content 2',
+				'post_status' => 'draft',
+				'post_author' => 9999
+			)
+		);
+
+		$this->assertTrue( user_can( $id, 'edit_post', $post ) );
+		$this->assertFalse( user_can( $id, 'edit_post', $others ) );
+
+	}
+
+
+}


### PR DESCRIPTION
This PR adds support for users functions :) 

Here is a non-exaustive list of functions supported:

* `wp_insert_user`
* `wp_update_user`
* `wp_delete_user`
* `get_userdata`
* `new WP_User( $id )` to fetch a user
* `user_can`
* `current_user_can`
* `set_current_user`
* `get_current_user_id`
* `wp_get_current_user`
* `get_user_meta`
* `update_user_meta`
* `add_user_meta`
* `delete_user_meta`

## Test instructions

* Look at the code (note: `Metadata.php` is just code moved around, disconsider)
* Look at `test-users.php` in the tests
* If you think of something else, try writing a couple of tests emulating a use case.