### PR TITLE
Keep existing Ubuntu version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,7 +17,7 @@ jobs:
   coding-standards:
     name: "Coding Standards"
 
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-18.04"
 
     strategy:
       matrix:
@@ -95,7 +95,7 @@ jobs:
   static-code-analysis:
     name: "Static Code Analysis"
 
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-18.04"
 
     strategy:
       matrix:
@@ -176,7 +176,7 @@ jobs:
   tests:
     name: "Tests"
 
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-18.04"
 
     strategy:
       matrix:
@@ -231,7 +231,7 @@ jobs:
   tests-old:
     name: "Tests on unsupported PHP"
 
-    runs-on: "ubuntu-latest"
+    runs-on: "ubuntu-18.04"
 
     strategy:
       matrix:


### PR DESCRIPTION
https://github.com/actions/virtual-environments/issues/1816

_Brave guys live next door_ A very far next door.

> Avoiding installation of new major version releases of any software in production, letting others test it first

https://gist.github.com/szepeviktor/6c5b75f84e5c999eb8232cd963c8e6f5