### PR TITLE
Add PHP 8 / PHPUnit 9.0 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,7 @@ jobs:
     strategy:
       matrix:
         php-version:
+          - "8.0"
           - "7.4"
           - "7.3"
           - "7.2"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -191,6 +191,11 @@ jobs:
           - "locked"
           - "highest"
 
+        exclude:
+          # Exclude locked on PHP 8 for now, as the locked dependencies specify PHPUnit 7.5.
+          - php-version: "8.0"
+            depencencies: "locked"
+
     steps:
       - name: "Checkout"
         uses: "actions/checkout@v2.3.2"
@@ -216,7 +221,7 @@ jobs:
 
       - name: "Install lowest dependencies from composer.json"
         if: "matrix.dependencies == 'lowest'"
-        run: "composer require --no-interaction --no-progress --no-suggest --prefer-lowest --dev 'phpunit/phpunit:^6.5 || ^7.5'"
+        run: "composer require --no-interaction --no-progress --no-suggest --prefer-lowest --dev 'phpunit/phpunit:^6.5 || ^7.5 || ^9.0'"
 
       - name: "Install locked dependencies from composer.lock"
         if: "matrix.dependencies == 'locked'"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -192,9 +192,11 @@ jobs:
           - "highest"
 
         exclude:
-          # Exclude locked on PHP 8 for now, as the locked dependencies specify PHPUnit 7.5.
+          # Exclude these on PHP 8 for now, as the locked dependencies aren't good enough
           - php-version: "8.0"
             dependencies: "locked"
+          - php-version: "8.0"
+            dependencies: "lowest"
 
     steps:
       - name: "Checkout"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,7 +194,7 @@ jobs:
         exclude:
           # Exclude locked on PHP 8 for now, as the locked dependencies specify PHPUnit 7.5.
           - php-version: "8.0"
-            depencencies: "locked"
+            dependencies: "locked"
 
     steps:
       - name: "Checkout"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ class My_Tests extends \WorDBless\BaseTestCase {
 ```
 Note WorDBless uses `@before` and `@after` annotations rather than overriding PHPUnit's `setUp` and `tearDown` methods.
 
-If you choose not to extend this base class, no problem. Just remember that WorDBless won't be set up or torn down for you.
+If you choose not to extend this base class, no problem. Just remember that WorDBless won't be set up or torn down for you. Check BaseTestCase::set_up_wordbless() and BaseTestCase::teardown_wordbless() to see how to do it for yourself.
 
 ## What will work and what will not work?
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ That's it! You can now use WordPress core functions in your tests!
 
 ### Writing tests
 
-Extend the `BaseTestCase` in order to have all the `setUp` and `tearDown`in place.
+Extend the `BaseTestCase` in order to have all the setup and teardown in place.
 
 ```php
 class My_Tests extends \WorDBless\BaseTestCase {
@@ -50,8 +50,9 @@ class My_Tests extends \WorDBless\BaseTestCase {
 
 }
 ```
+Note WorDBless uses `@before` and `@after` annotations rather than overriding PHPUnit's `setUp` and `tearDown` methods.
 
-If you choose not to extend this base class, no problem, just make sure to call its `setUp` and `tearDown` methods.
+If you choose not to extend this base class, no problem. Just remember that WorDBless won't be set up or torn down for you.
 
 ## What will work and what will not work?
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
 		"roots/wordpress": "^5.4"
 	},
 	"require-dev": {
-		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+		"phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^9.0"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1e8d6a45057ae6fbad300c91f7ad4eab",
+    "content-hash": "1808b23cf12cce464584de4aa29f385d",
     "packages": [
         {
             "name": "roots/wordpress",

--- a/src/BaseTestCase.php
+++ b/src/BaseTestCase.php
@@ -10,8 +10,10 @@ abstract class BaseTestCase extends TestCase {
 
 	/**
 	 * Runs the routine before each test is executed.
+	 *
+	 * @before
 	 */
-	public function setUp() {
+	public function set_up_wordbless() {
 		if ( ! self::$hooks_saved ) {
 			$this->_backup_hooks();
 		}
@@ -19,8 +21,10 @@ abstract class BaseTestCase extends TestCase {
 
 	/**
 	 * After a test method runs, reset any state in WordPress the test method might have changed.
+	 *
+	 * @after
 	 */
-	public function tearDown() {
+	public function tear_down_wordbless() {
 		$this->_restore_hooks();
 		Options::init()->clear_options();
 		Posts::init()->clear_all_posts();

--- a/tests/includes/setup-test-for-phpunit-pre8.php
+++ b/tests/includes/setup-test-for-phpunit-pre8.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WorDBless;
+
+class Test_Setup_Teardown extends Test_Setup_Teardown_Base {
+
+	public function setUp() {
+		$this->setup_called = true;
+	}
+
+	public function tearDown() {
+		self::$teardown_called = true;
+	}
+
+	/**
+	 * @before
+	 */
+	public function custom_setup() {
+		$this->custom_setup_called = true;
+	}
+
+	/**
+	 * @after
+	 */
+	public function custom_teardown() {
+		self::$custom_teardown_called = true;
+	}
+
+}

--- a/tests/includes/setup-test-for-phpunit8+.php
+++ b/tests/includes/setup-test-for-phpunit8+.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace WorDBless;
+
+class Test_Setup_Teardown extends Test_Setup_Teardown_Base {
+
+	public function setUp(): void {
+		$this->setup_called = true;
+	}
+
+	public function tearDown(): void {
+		self::$teardown_called = true;
+	}
+
+	/**
+	 * @before
+	 */
+	public function custom_setup() {
+		$this->custom_setup_called = true;
+	}
+
+	/**
+	 * @after
+	 */
+	public function custom_teardown() {
+		self::$custom_teardown_called = true;
+	}
+
+}

--- a/tests/test-setup-teardown.php
+++ b/tests/test-setup-teardown.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace WorDBless;
+
+abstract class Test_Setup_Teardown_Base extends BaseTestCase {
+
+	protected $setup_called = false;
+	protected $custom_setup_called = false;
+	protected static $teardown_called = false;
+	protected static $custom_teardown_called = false;
+	protected static $wordbless_teardown_called = false;
+
+	public function test_setup_called() {
+		$this->assertTrue( $this->setup_called, static::class . ' setup called?' );
+		$this->assertTrue( $this->custom_setup_called, static::class . ' custom setup called?' );
+		$this->assertNotEmpty( self::$hooks_saved, 'WorDBless setup called?' );
+
+		return true;
+	}
+
+	/**
+	 * @depends test_setup_called
+	 */
+	public function test_teardown_called( $setup ) {
+		if ( ! $setup ) {
+			$this->markTestSkipped( static::class . '::test_setup_called was not run?' );
+		}
+
+		$this->assertTrue( self::$teardown_called, static::class . ' teardown called?' );
+		$this->assertTrue( self::$custom_teardown_called, static::class . ' custom teardown called?' );
+		$this->assertTrue( self::$wordbless_teardown_called, 'WorDBless teardown called?' );
+	}
+
+	/**
+	 * We override this as a proxy for WorDBless's teardown being called.
+	 */
+	protected function _restore_hooks() {
+		self::$wordbless_teardown_called = true;
+		parent::_restore_hooks();
+	}
+
+}
+
+if ( class_exists( \PHPUnit\Runner\Version::class ) && version_compare( \PHPUnit\Runner\Version::id(), '8.0', '>=' ) ) {
+	require 'tests/includes/setup-test-for-phpunit8+.php';
+} else {
+	require 'tests/includes/setup-test-for-phpunit-pre8.php';
+}


### PR DESCRIPTION
PHPUnit doesn't support PHP 8 until version 9.0, so we need to be
compatible with that while still maintaining compatibility with PHPUnit
5.7.

Fortunately the only thing WorDBLess\BaseTestCase does that's not
compatible with both 5.7 and 9.0 is its use of `setUp` and `tearDown`,
and we can work around that by using `@before` and `@after` instead of
overriding those methods.

Also this adds some tests to verify that the `@before` and `@after`
methods are still called even if a subclass overrides `setUp`/`tearDown`
or supplies its own `@before`/`@after`.