### PR TITLE
Change site_url option to siteurl

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ Note: Fetching users using `WP_Users_Query` will not work! To fetch a user, use 
 
 ### Populating default options
 
-By default, only `site_url` and `home` options are populated with `http://example.org`.
+By default, only `siteurl` and `home` options are populated with `http://example.org`.
 
 If you want, you can add more options to be loaded by default. 
 

--- a/src/Options.php
+++ b/src/Options.php
@@ -68,7 +68,7 @@ class Options {
 	 */
 	public function get_default_options() {
 		return array(
-			'site_url' => 'http://example.org',
+			'siteurl' => 'http://example.org',
 			'home'     => 'http://example.org',
 		);
 	}


### PR DESCRIPTION
I think the `site_url` option name should be `siteurl`. The core WordPress function `get_site_url` gets the `siteurl` option (see the function [here](https://core.trac.wordpress.org/browser/tags/5.7.1/src/wp-includes/link-template.php#L3336)).