### PR TITLE
Change the option array merge order in Options::get_all_options

### DIFF
--- a/src/Options.php
+++ b/src/Options.php
@@ -92,10 +92,10 @@ class Options {
 		}
 
 		$all_options = array_merge(
-			$this->options,
 			$defaults,
 			$options,
-			$custom_defaults
+			$custom_defaults,
+			$this->options
 		);
 		$this->clear_cache_group();
 

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -50,10 +50,10 @@ class Test_Options extends BaseTestCase {
 
 	/**
 	 * Test that update_option changes the value of an option that has a default value.
-	 * The 'home' option has a default value. See Options::get_default_options.
+	 * The 'home' option has a default value, 'http://example.org'. See Options::get_default_options.
 	 */
 	public function test_update_option_with_default_value() {
-		$new_url = 'http://coolsite.com';
+		$new_url = 'https://www.example.com';
 		update_option( 'home', $new_url );
 		$this->assertSame( $new_url, get_option( 'home', null ) );
 	}

--- a/tests/test-options.php
+++ b/tests/test-options.php
@@ -48,4 +48,14 @@ class Test_Options extends BaseTestCase {
 
 	}
 
+	/**
+	 * Test that update_option changes the value of an option that has a default value.
+	 * The 'home' option has a default value. See Options::get_default_options.
+	 */
+	public function test_update_option_with_default_value() {
+		$new_url = 'http://coolsite.com';
+		update_option( 'home', $new_url );
+		$this->assertSame( $new_url, get_option( 'home', null ) );
+	}
+
 }


### PR DESCRIPTION
Change the option array merge order in `Options::get_all_options` so that the `$options` class property is merged last. This will allow tests to use `update_option` to change the value of options that have a default value, such as the 'home' option.

Also add a unit test that verifies that `update_option` will change the value of an option that has a default value. Note that without this branch's change to `Options::get_all_options`, the new unit test should fail.