### PR TITLE
Remove zero empty-check from insert_post

### DIFF
--- a/src/Posts.php
+++ b/src/Posts.php
@@ -35,7 +35,7 @@ class Posts {
 
 	public function insert_post( $data, $postarr, $unsanitized_postarr = array() ) {
 
-		$post_ID = empty( $postarr['ID'] ) ? InsertId::bump_and_get() : $post_ID = $postarr['ID'];
+		$post_ID = empty( $postarr['ID'] ) ? InsertId::bump_and_get() : $postarr['ID'];
 
 		$data['ID'] = $post_ID;
 

--- a/src/Posts.php
+++ b/src/Posts.php
@@ -35,11 +35,7 @@ class Posts {
 
 	public function insert_post( $data, $postarr, $unsanitized_postarr = array() ) {
 
-		if ( empty( $postarr['ID'] ) || 0 === $postarr['ID'] ) {
-			$post_ID = InsertId::bump_and_get();
-		} else {
-			$post_ID = $postarr['ID'];
-		}
+		$post_ID = empty( $postarr['ID'] ) ? InsertId::bump_and_get() : $post_ID = $postarr['ID'];
 
 		$data['ID'] = $post_ID;
 


### PR DESCRIPTION
Because

```php
$postarr = ['ID' => 0];
var_dump(empty($postarr['ID'])); // true
```

Conclusion: DO NOT use empty.