### PR TITLE
Fix autoloading

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ Add this script to your `composer.json`:
 
 ```json
     "scripts": {
-        "post-update-cmd": "php -r \"copy('vendor/automattic/wordbless/src/dbless-wpdb.php', 'wordpress/wp-content/db.php');\""
+        "post-install-cmd": "WorDBless\\Composer\\InstallDropin::copy",
+		"post-update-cmd": "WorDBless\\Composer\\InstallDropin::copy"
     },
 ```
 
-Alternatively, you can manually copy the file.
+Alternatively, you can manually copy `src/dbless-wpdb.php` to the `wordpress` folder created in your project under `wp-content/db.php`.
 
 ### Initialize it in your bootstrap file
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
 	},
 	"autoload": {
 		"psr-4": {
-			"WorDBless\\": "src/"
+			"WorDBless\\": "src/",
+			"WorDBless\\Composer\\": "src/Composer/"
 		}
 	},
 	"scripts": {

--- a/src/Composer/InstallDropin.php
+++ b/src/Composer/InstallDropin.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * This is the installation script to copy the db dropin plugin into WordPress.
  *
@@ -14,6 +13,6 @@ class InstallDropin {
 			mkdir( 'wordpress/wp-content' );
 		}
 
-		copy( 'src/dbless-wpdb.php', 'wordpress/wp-content/db.php' );
+		copy( dirname( __DIR__ ) . '/dbless-wpdb.php', 'wordpress/wp-content/db.php' );
 	}
 }


### PR DESCRIPTION
Fixes the following error when using WorDBless as a dependency

and updates the README

```
Class WorDBless\Composer\InstallDropin is not autoloadable, can not call post-update-cmd script
```